### PR TITLE
Handle space in Strigo resource name when setting VM hostname

### DIFF
--- a/scripts/strigo.sh
+++ b/scripts/strigo.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Force hostname
-hostnamectl set-hostname {{ .STRIGO_RESOURCE_NAME }}
-sed --in-place "0,/^127.0.0.1/s/$/ {{ .STRIGO_RESOURCE_NAME }}/" /etc/hosts
+hostnamectl set-hostname '{{ .STRIGO_RESOURCE_NAME }}'
+sed --in-place "0,/^127.0.0.1/s/$/ $(hostnamectl status --static)/" /etc/hosts
 
 apt-get install -y curl
 
 # Inject Strigo context
 cat <<\EOF > /etc/profile.d/00_strigo_context.sh
 # Strigo context
-export INSTANCE_NAME={{ .STRIGO_RESOURCE_NAME }}
+export INSTANCE_NAME='{{ .STRIGO_RESOURCE_NAME }}'
 export PUBLIC_DNS={{ .STRIGO_RESOURCE_DNS }}
 export PUBLIC_IP=$(curl --silent ifconfig.co)
 export PRIVATE_DNS={{ .STRIGO_RESOURCE_DNS }}
 export PRIVATE_IP=$(dig +short {{ .STRIGO_RESOURCE_DNS }})
-export HOSTNAME={{ .STRIGO_RESOURCE_NAME }}
+export HOSTNAME='{{ .STRIGO_RESOURCE_NAME }}'
 EOF


### PR DESCRIPTION
```shell
$ hostnamectl status 
   Static hostname: test
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 66c6b62494e24afdb446b5b2470fde01
           Boot ID: eb7b29653c164ca5940eb0980c153c31
    Virtualization: oracle
  Operating System: Ubuntu 20.04.1 LTS
            Kernel: Linux 5.4.0-80-generic
      Architecture: x86-64

$ sudo hostnamectl set-hostname 'host with space'

$ hostnamectl status 
   Static hostname: hostwithspace
   Pretty hostname: host with space
         Icon name: computer-vm
           Chassis: vm
        Machine ID: 66c6b62494e24afdb446b5b2470fde01
           Boot ID: eb7b29653c164ca5940eb0980c153c31
    Virtualization: oracle
  Operating System: Ubuntu 20.04.1 LTS
            Kernel: Linux 5.4.0-80-generic
      Architecture: x86-64

$ hostnamectl status --static
hostwithspace
```