### PR TITLE
Pre-setup keyboard in Windows VMs

### DIFF
--- a/win_scripts/keyboard.ps1
+++ b/win_scripts/keyboard.ps1
@@ -1,0 +1,11 @@
+# Set language to fr-FR then en-US
+Set-WinUserLanguageList -Force -LanguageList fr-FR,en-US
+# Set default input method to fr-FR
+Set-WinDefaultInputMethodOverride -InputTip ((Get-WinUserLanguageList)[0].InputMethodTips)[0]
+
+# Disable Language Bar HotKey
+Set-ItemProperty -Path 'Registry::HKEY_CURRENT_USER\Keyboard Layout\Toggle' -Name 'Language HotKey' -Value 3
+Set-ItemProperty -Path 'Registry::HKEY_CURRENT_USER\Keyboard Layout\Toggle' -Name 'HotKey' -Value 3
+Set-ItemProperty -Path 'Registry::HKEY_CURRENT_USER\Keyboard Layout\Toggle' -Name 'Layout HotKey' -Value 3
+
+# Then, need to change "Keyboard language settings" in Strigo and change language in the Windows language bar (or sign out from Windows)


### PR DESCRIPTION
Quand même besoin de switcher la config du clavier dans Strigo (comme pour Linux dans http://help.strigo.io/en/articles/5661984-how-to-change-you-keyboard-language-settings) + changer dans la barre de langue.

Cependant, si on change au niveau Strigo pendant que la VM est encore en initialisation alors on est direct en FR.