### PR TITLE
🐛 Fix pip3/gdown installation, add apt-get update before install.

### DIFF
--- a/scripts/code-server.sh
+++ b/scripts/code-server.sh
@@ -20,6 +20,7 @@ set -e
 
 # Install code-server (last released version by default)
 # https://github.com/coder/code-server/blob/main/docs/install.md#debian-ubuntu
+apt-get update
 apt-get install -y curl
 last_code_server_release=$(curl -sL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/coder/code-server/releases/latest | grep -Po '/code-server/releases/tag/v\K[^"]*')
 code_server_version=${code_server_version:-${last_code_server_release}}

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -11,6 +11,7 @@ set -e
 # Install docker-compose (last released version by default)
 # https://docs.docker.com/compose/install/
 
+apt-get update
 apt-get install -y curl
 last_docker_compose_release=$(curl -sL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/docker/compose/releases/latest | grep -Po 'docker/compose/releases/tag/v\K[^"]*')
 docker_compose_version=${docker_compose_version:-${last_docker_compose_release}}

--- a/scripts/materials-helper.sh
+++ b/scripts/materials-helper.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+apt-get update
 apt-get install -y --no-install-recommends unzip python3 python3-pip
 pip3 install gdown
 

--- a/scripts/strigo.sh
+++ b/scripts/strigo.sh
@@ -5,6 +5,7 @@ hostnamectl set-hostname '{{ .STRIGO_RESOURCE_NAME }}'
 sed --in-place "0,/^127.0.0.1/s/$/ $(hostnamectl status --static) $(hostnamectl status --static).zenika.labs.strigo.io/" /etc/hosts
 
 # Install https://github.com/canonical/cloud-utils to have 'ec2metadata'
+apt-get update
 apt-get install -y cloud-guest-utils
 
 # Inject Strigo context


### PR DESCRIPTION
J'ai pu constater un problème d'installation de `pip3` (et donc `gdown`) en fonction de l'ordre d'import dans le fichier `strigo.json`.
Après avoir un peu chercher, j'ai finalement trouver la cause, un `apt-get update` absent dans `materials-helper.sh`
Je propose donc de systématiquement ajouté un update avant un install :) 